### PR TITLE
Add icon and release notes links to nuspec

### DIFF
--- a/dart-sdk/dart-sdk.nuspec
+++ b/dart-sdk/dart-sdk.nuspec
@@ -13,12 +13,12 @@ Dart is a cohesive, scalable platform for building apps that run on the web (whe
     <version>$version$</version>
     <authors>The Dart project authors</authors>
     <owners>athomas</owners>
-    <licenseUrl>http://opensource.org/licenses/BSD-3-Clause</licenseUrl>
-    <projectUrl>http://dart.dev/</projectUrl>
+    <licenseUrl>https://opensource.org/licenses/BSD-3-Clause</licenseUrl>
+    <projectUrl>https://dart.dev/</projectUrl>
     <iconUrl>https://dart.dev/f/dart-logo-1080.png</iconUrl>
     <projectSourceUrl>https://github.com/dart-lang/sdk</projectSourceUrl>
     <packageSourceUrl>https://github.com/dart-lang/chocolatey-packages</packageSourceUrl>
-    <bugTrackerUrl>http://dartbug.com</bugTrackerUrl>
+    <bugTrackerUrl>https://dartbug.com</bugTrackerUrl>
     <docsUrl>https://api.dart.dev/</docsUrl>
     <mailingListUrl>https://groups.google.com/a/dartlang.org/forum/#!forum/misc</mailingListUrl>
     <tags>Dart DartLang SDK Development VirtualMachine JSTranspiler Compiler</tags>

--- a/dart-sdk/dart-sdk.nuspec
+++ b/dart-sdk/dart-sdk.nuspec
@@ -3,21 +3,23 @@
   <metadata>
     <title>Dart SDK</title>
     <id>dart-sdk</id>
+    <summary>The Dart SDK has the libraries and command-line tools that you need to develop Dart applications.</summary>
     <description><![CDATA[
 The Dart SDK has the libraries and command-line tools that you need to develop Dart applications.
 
 Dart is a cohesive, scalable platform for building apps that run on the web (where you can use Angular2 or Polymer) or on servers (such as with Google Cloud Platform). Use the Dart language, libraries, and tools to write anything from simple scripts to full-featured apps on the web or mobile with the Flutter platform.
  ]]></description>
-    <summary>The Dart SDK has the libraries and command-line tools that you need to develop Dart applications.</summary>
+    <releaseNotes>https://github.com/dart-lang/sdk/blob/master/CHANGELOG.md</releaseNotes>
     <version>$version$</version>
     <authors>The Dart project authors</authors>
     <owners>athomas</owners>
     <licenseUrl>http://opensource.org/licenses/BSD-3-Clause</licenseUrl>
-    <projectUrl>http://www.dartlang.org/</projectUrl>
+    <projectUrl>http://dart.dev/</projectUrl>
+    <iconUrl>https://dart.dev/f/dart-logo-1080.png</iconUrl>
     <projectSourceUrl>https://github.com/dart-lang/sdk</projectSourceUrl>
     <packageSourceUrl>https://github.com/dart-lang/chocolatey-packages</packageSourceUrl>
     <bugTrackerUrl>http://dartbug.com</bugTrackerUrl>
-    <docsUrl>https://api.dartlang.org/</docsUrl>
+    <docsUrl>https://api.dart.dev/</docsUrl>
     <mailingListUrl>https://groups.google.com/a/dartlang.org/forum/#!forum/misc</mailingListUrl>
     <tags>Dart DartLang SDK Development VirtualMachine JSTranspiler Compiler</tags>
   </metadata>


### PR DESCRIPTION
This will fix the lints chocolatey complains about on every release.

Also changes some links to dart.dev.