### PR TITLE
Use updated PATH

### DIFF
--- a/dart-sdk/chocolateyInstall.ps1
+++ b/dart-sdk/chocolateyInstall.ps1
@@ -7,8 +7,8 @@ $unzipLocation = Get-ToolsLocation
 $installDir = Join-Path $unzipLocation "dart-sdk"
 
 Install-ChocolateyPath "$installDir\bin"
-Install-ChocolateyPath "${env:USERPROFILE}\AppData\Roaming\Pub\Cache\bin"
-$env:Path = "$($env:Path);$installDir\bin;${env:USERPROFILE}\AppData\Roaming\Pub\Cache\bin"
+Install-ChocolateyPath "${env:USERPROFILE}\AppData\Local\Pub\Cache\bin"
+$env:Path = "$($env:Path);$installDir\bin;${env:USERPROFILE}\AppData\Local\Pub\Cache\bin"
 
 if (test-path $installDir) {
 	Remove-Item $installDir -Recurse -Force


### PR DESCRIPTION
The install file currently uses the AppData\Roaming PATH, however this was changed in a recent version of dart to now use AppData\Local

Simple PR  to fix this so globally activated packages can be used