### PR TITLE
Change usage of Get-BinRoot to Get-ToolsLocation

### DIFF
--- a/dart-sdk/chocolateyUninstall.ps1
+++ b/dart-sdk/chocolateyUninstall.ps1
@@ -1,4 +1,4 @@
-$unzipLocation = Get-BinRoot
+$unzipLocation = Get-ToolsLocation
 $installDir = Join-Path $unzipLocation "dart-sdk"
 
 if (test-path $installDir) {


### PR DESCRIPTION
Based on:
https://docs.chocolatey.org/en-us/community-repository/moderation/package-validator/rules/cpmr0035

The Get-BinRoot command is deprecated/removed and should be replaced with Get-ToolsLocation.

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

Solves: https://github.com/dart-lang/chocolatey-packages/issues/9

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
